### PR TITLE
비관적 락 사용 (데드락 방지)

### DIFF
--- a/src/main/java/com/woopaca/knoo/entity/Comment.java
+++ b/src/main/java/com/woopaca/knoo/entity/Comment.java
@@ -6,15 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -82,10 +74,9 @@ public class Comment {
         post.commentWritten(this);
     }
 
-    public void reply(final User writer, final Comment parentComment) {
+    public void reply(final Comment parentComment, Post post) {
         this.parentComment = parentComment;
 
-        Post post = parentComment.getPost();
         this.post = post;
         post.commentWritten(this);
     }

--- a/src/main/java/com/woopaca/knoo/exception/comment/CommentError.java
+++ b/src/main/java/com/woopaca/knoo/exception/comment/CommentError.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 public enum CommentError implements KnooError {
+
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글이 존재하지 않습니다.", "KN401");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/woopaca/knoo/repository/PostRepository.java
+++ b/src/main/java/com/woopaca/knoo/repository/PostRepository.java
@@ -5,11 +5,14 @@ import com.woopaca.knoo.entity.PostCategory;
 import com.woopaca.knoo.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -26,4 +29,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p LEFT JOIN p.postLikes pl " +
             "WHERE pl.user = :user ORDER BY pl.id DESC")
     List<Post> findByLikeUser(@Param("user") User user, Pageable pageable);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    Optional<Post> findPostById(Long postId);
 }

--- a/src/main/java/com/woopaca/knoo/validator/impl/BasicAuthValidator.java
+++ b/src/main/java/com/woopaca/knoo/validator/impl/BasicAuthValidator.java
@@ -5,14 +5,7 @@ import com.woopaca.knoo.controller.dto.auth.SignInRequestDto;
 import com.woopaca.knoo.controller.dto.auth.SignUpRequestDto;
 import com.woopaca.knoo.entity.EmailVerify;
 import com.woopaca.knoo.entity.User;
-import com.woopaca.knoo.exception.user.impl.AlreadyMailVerifiedException;
-import com.woopaca.knoo.exception.user.impl.DuplicateEmailException;
-import com.woopaca.knoo.exception.user.impl.DuplicateNameException;
-import com.woopaca.knoo.exception.user.impl.DuplicateUsernameException;
-import com.woopaca.knoo.exception.user.impl.IncompleteMailVerificationException;
-import com.woopaca.knoo.exception.user.impl.InconsistentPasswordCheck;
-import com.woopaca.knoo.exception.user.impl.IncorrectUsernameOrPasswordException;
-import com.woopaca.knoo.exception.user.impl.InvalidEmailDomainException;
+import com.woopaca.knoo.exception.user.impl.*;
 import com.woopaca.knoo.repository.UserRepository;
 import com.woopaca.knoo.validator.AuthValidator;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +82,11 @@ public class BasicAuthValidator implements AuthValidator {
 
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(username, password);
+        return validateAuthentication(authenticationToken);
+    }
+
+    private Authentication validateAuthentication(
+            final UsernamePasswordAuthenticationToken authenticationToken) {
         try {
             return authenticationManagerBuilder.getObject()
                     .authenticate(authenticationToken);


### PR DESCRIPTION
- Spring Data JPA `@Lock` 애노테이션을 사용하여 `LockModeType.PESSIMISTIC_WRITE` 설정
- `SELECT ... FOR UPDATE` (하나의 트랜잭션만 해당 row에 접근 가능. 나머지 트랜잭션은 대기)