### PR TITLE
게시글 본문 글자 수 제한 오류 수정

### DIFF
--- a/src/main/java/com/woopaca/knoo/controller/dto/post/WritePostRequestDto.java
+++ b/src/main/java/com/woopaca/knoo/controller/dto/post/WritePostRequestDto.java
@@ -25,7 +25,7 @@ public class WritePostRequestDto {
 
     @JsonAlias(value = "post_content")
     @NotBlank(message = "게시글 본문은 비어있을 수 없습니다.")
-    @Size(min = 2, max = 50, message = "게시글 본문은 2자 이상, 4000자 이하이어야 합니다.")
+    @Size(min = 2, max = 4000, message = "게시글 본문은 2자 이상, 4000자 이하이어야 합니다.")
     private String postContent;
 
     @JsonAlias(value = "post_category")


### PR DESCRIPTION
기존: 게시글 본문이 50자 이하로 제한되어 있었음
변경: 4000자 까지 가능하도록 수정