### PR TITLE
feat: 게시글 이미지 등록 기능

### DIFF
--- a/src/main/java/com/woopaca/knoo/config/security/SecurityConfig.java
+++ b/src/main/java/com/woopaca/knoo/config/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.woopaca.knoo.exception.handler.security.CustomAuthenticationEntryPoin
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -27,6 +28,8 @@ public class SecurityConfig {
                 .authorizeRequests()
                 // permitAll() -> 모두 허용     authenticated() -> 인증 필요     hasRole() -> 권한 필요
                 .antMatchers("/api/auth/**", "/mail-verify").permitAll()
+                .antMatchers(HttpMethod.POST, "/api/notifications/**").permitAll()
+                .antMatchers(HttpMethod.GET, "/api/notifications/**").permitAll()
                 .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/woopaca/knoo/controller/NotificationController.java
+++ b/src/main/java/com/woopaca/knoo/controller/NotificationController.java
@@ -1,0 +1,53 @@
+package com.woopaca.knoo.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@RequestMapping("/api/notifications")
+@RestController
+public class NotificationController {
+
+    private SseEmitter sseEmitter;
+
+    @GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter createConnection() {
+        sseEmitter = new SseEmitter();
+        log.info("SSE connection");
+        try {
+            sseEmitter.send("Hello!");
+        } catch (IOException e) {
+            sseEmitter.completeWithError(e);
+        }
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        //Creating a new thread for async processing
+        executor.execute(() -> {
+        });
+        executor.shutdown();
+
+        sseEmitter.onCompletion(() -> log.info("Sse Complete"));
+        return sseEmitter;
+    }
+
+    @PostMapping("/sse")
+    public void inputData(@RequestParam(name = "data") String data) {
+        try {
+            sseEmitter.send(SseEmitter.event().data(data));
+            log.info("data = {}", data);
+        } catch (IOException e) {
+            sseEmitter.completeWithError(e);
+        }
+    }
+}

--- a/src/main/java/com/woopaca/knoo/controller/PostController.java
+++ b/src/main/java/com/woopaca/knoo/controller/PostController.java
@@ -12,8 +12,10 @@ import com.woopaca.knoo.controller.dto.post.UpdatePostRequestDto;
 import com.woopaca.knoo.controller.dto.post.WritePostRequestDto;
 import com.woopaca.knoo.entity.value.PostCategory;
 import com.woopaca.knoo.service.PostService;
+import com.woopaca.knoo.service.impl.ImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,7 +26,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
@@ -39,6 +43,7 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
+    private final ImageService imageService;
 
     @GetMapping
     public ResponseEntity<List<PostPreviewResponseDto>> postPreviewList() {
@@ -116,5 +121,22 @@ public class PostController {
             @Valid final PostSearchRequestDto postSearchRequestDto) {
         PostListResponseDto postListResponseDto = postService.searchPosts(postSearchRequestDto);
         return ResponseEntity.ok().body(postListResponseDto);
+    }
+
+    @PostMapping("/images")
+    public ResponseEntity<String> uploadPostImages(
+            @SignIn SignInUser signInUser,
+            @RequestPart(name = "post_images") final List<MultipartFile> postImageFiles,
+            @RequestParam(name = "post_id") final Long postId
+    ) {
+        postService.uploadPostImageFiles(postId, postImageFiles, signInUser);
+        return ResponseEntity.ok().body("게시글 사진이 등록되었습니다.");
+    }
+
+    @GetMapping(value = "/images/{imageId}",
+            produces = {MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE})
+    public ResponseEntity<byte[]> postImage(@PathVariable("imageId") final Long imageId) {
+        byte[] imageBytes = imageService.getPostImageBytes(imageId);
+        return ResponseEntity.ok().body(imageBytes);
     }
 }

--- a/src/main/java/com/woopaca/knoo/controller/dto/post/PostDetailsResponseDto.java
+++ b/src/main/java/com/woopaca/knoo/controller/dto/post/PostDetailsResponseDto.java
@@ -3,6 +3,7 @@ package com.woopaca.knoo.controller.dto.post;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.woopaca.knoo.entity.Comment;
 import com.woopaca.knoo.entity.CommentLike;
+import com.woopaca.knoo.entity.Image;
 import com.woopaca.knoo.entity.Post;
 import com.woopaca.knoo.entity.PostLike;
 import com.woopaca.knoo.entity.Scrap;
@@ -71,11 +72,13 @@ public class PostDetailsResponseDto {
 
         private Boolean scrapped;
 
+        private List<Long> images;
+
         @Builder
         public PostDetailsDto(
                 String postTitle, String postContent, String postCategory, String postDate,
                 String writerName, int commentsCount, int likesCount, int scrapsCount,
-                Boolean isWrittenByUser, Boolean liked, Boolean scrapped
+                Boolean isWrittenByUser, Boolean liked, Boolean scrapped, List<Long> images
         ) {
             this.postTitle = postTitle;
             this.postContent = postContent;
@@ -88,6 +91,7 @@ public class PostDetailsResponseDto {
             this.isWrittenByUser = isWrittenByUser;
             this.liked = liked;
             this.scrapped = scrapped;
+            this.images = images;
         }
 
         public static PostDetailsDto of(final Post post, final User authenticatedUser) {
@@ -112,6 +116,9 @@ public class PostDetailsResponseDto {
                     .isWrittenByUser(isWrittenByUser)
                     .liked(liked)
                     .scrapped(scrapped)
+                    .images(post.getImages().stream()
+                            .map(Image::getId)
+                            .collect(toList()))
                     .build();
         }
 

--- a/src/main/java/com/woopaca/knoo/entity/Image.java
+++ b/src/main/java/com/woopaca/knoo/entity/Image.java
@@ -1,0 +1,47 @@
+package com.woopaca.knoo.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "image")
+@Entity
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(name = "image_name")
+    private String imageName;
+
+    @JoinColumn(name = "post_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    protected Image(String imageName) {
+        this.imageName = imageName;
+    }
+
+    public static Image of(String imageName) {
+        return new Image(imageName);
+    }
+
+    public void uploadWith(Post post) {
+        this.post = post;
+        post.getImages().add(this);
+    }
+}

--- a/src/main/java/com/woopaca/knoo/entity/Post.java
+++ b/src/main/java/com/woopaca/knoo/entity/Post.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -24,6 +23,10 @@ import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.REMOVE;
 
 @Entity
 @Getter
@@ -65,14 +68,17 @@ public class Post {
     @JoinColumn(name = "user_id")
     private User writer;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "post", cascade = REMOVE)
     private List<PostLike> postLikes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "post", cascade = REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "post", cascade = REMOVE)
     private List<Scrap> scraps = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = {PERSIST, MERGE, REMOVE})
+    private List<Image> images = new ArrayList<>();
 
     @Builder
     public Post(String postTitle, String postContent, PostCategory postCategory,

--- a/src/main/java/com/woopaca/knoo/entity/User.java
+++ b/src/main/java/com/woopaca/knoo/entity/User.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
@@ -156,5 +157,20 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+
+        User user = (User) object;
+
+        return Objects.equals(id, user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
     }
 }

--- a/src/main/java/com/woopaca/knoo/exception/post/PostError.java
+++ b/src/main/java/com/woopaca/knoo/exception/post/PostError.java
@@ -10,7 +10,10 @@ public enum PostError implements KnooError {
     POST_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리가 존재하지 않습니다.", "KN301"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다.", "KN302"),
     OUT_OF_PAGE(HttpStatus.BAD_REQUEST, "페이지 수를 초과하였습니다.", "KN303"),
-    INVALID_POST_PAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 페이지입니다.", "KN304");
+    INVALID_POST_PAGE(HttpStatus.BAD_REQUEST, "유효하지 않은 페이지입니다.", "KN304"),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다.", "KN305"),
+    IMAGE_CAN_NOT_READ(HttpStatus.INTERNAL_SERVER_ERROR, "이미지를 읽는 도중 오류가 발생하였습니다.", "KN306"),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지를 찾을 수 없습니다.", "KN307");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/woopaca/knoo/exception/post/impl/ImageNotFoundException.java
+++ b/src/main/java/com/woopaca/knoo/exception/post/impl/ImageNotFoundException.java
@@ -1,0 +1,11 @@
+package com.woopaca.knoo.exception.post.impl;
+
+import com.woopaca.knoo.exception.post.PostError;
+import com.woopaca.knoo.exception.post.PostException;
+
+public class ImageNotFoundException extends PostException {
+
+    public ImageNotFoundException() {
+        super(PostError.IMAGE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/woopaca/knoo/exception/post/impl/ImageNotReadable.java
+++ b/src/main/java/com/woopaca/knoo/exception/post/impl/ImageNotReadable.java
@@ -1,0 +1,11 @@
+package com.woopaca.knoo.exception.post.impl;
+
+import com.woopaca.knoo.exception.post.PostError;
+import com.woopaca.knoo.exception.post.PostException;
+
+public class ImageNotReadable extends PostException {
+
+    public ImageNotReadable() {
+        super(PostError.IMAGE_CAN_NOT_READ);
+    }
+}

--- a/src/main/java/com/woopaca/knoo/exception/post/impl/InvalidFileExtensionException.java
+++ b/src/main/java/com/woopaca/knoo/exception/post/impl/InvalidFileExtensionException.java
@@ -1,0 +1,11 @@
+package com.woopaca.knoo.exception.post.impl;
+
+import com.woopaca.knoo.exception.post.PostError;
+import com.woopaca.knoo.exception.post.PostException;
+
+public class InvalidFileExtensionException extends PostException {
+
+    public InvalidFileExtensionException() {
+        super(PostError.INVALID_FILE_EXTENSION);
+    }
+}

--- a/src/main/java/com/woopaca/knoo/repository/ImageRepository.java
+++ b/src/main/java/com/woopaca/knoo/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.woopaca.knoo.repository;
+
+import com.woopaca.knoo.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/woopaca/knoo/service/PostService.java
+++ b/src/main/java/com/woopaca/knoo/service/PostService.java
@@ -10,6 +10,7 @@ import com.woopaca.knoo.controller.dto.post.PostSearchRequestDto;
 import com.woopaca.knoo.controller.dto.post.UpdatePostRequestDto;
 import com.woopaca.knoo.controller.dto.post.WritePostRequestDto;
 import com.woopaca.knoo.entity.value.PostCategory;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -37,4 +38,5 @@ public interface PostService {
 
     PostListResponseDto searchUserScrapPosts(final SignInUser signInUser, final PostSearchRequestDto postSearchRequestDto);
 
+    void uploadPostImageFiles(final Long postId, final List<MultipartFile> postImageFiles, final SignInUser signInUser);
 }

--- a/src/main/java/com/woopaca/knoo/service/impl/ImageService.java
+++ b/src/main/java/com/woopaca/knoo/service/impl/ImageService.java
@@ -1,0 +1,114 @@
+package com.woopaca.knoo.service.impl;
+
+import com.woopaca.knoo.entity.Image;
+import com.woopaca.knoo.exception.post.impl.ImageNotFoundException;
+import com.woopaca.knoo.exception.post.impl.ImageNotReadable;
+import com.woopaca.knoo.exception.post.impl.InvalidFileExtensionException;
+import com.woopaca.knoo.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class ImageService {
+
+    private final ImageRepository imageRepository;
+
+    private Path path;
+    @Value(value = "${file.path}")
+    private String location;
+
+    @PostConstruct
+    private void init() {
+        this.path = Paths.get(location).toAbsolutePath().normalize();
+
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Transactional
+    public List<Image> multipartFilesStoreAndConvertToImages(final List<MultipartFile> multipartFiles) {
+        if (CollectionUtils.isEmpty(multipartFiles)) {
+            return List.of();
+        }
+
+        return multipartFiles.stream()
+                .map(multipartFile -> {
+                    String storedFileName;
+                    try {
+                        storedFileName = storeMultipartFile(multipartFile);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return Image.of(storedFileName);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private String storeMultipartFile(MultipartFile multipartFile) throws IOException {
+        String extension = getFileExtension(multipartFile);
+        String uuid = UUID.randomUUID().toString();
+        String fileName = uuid.concat(extension);
+        File file = new File(path + File.separator + fileName);
+        multipartFile.transferTo(file);
+        file.setWritable(true);
+        file.setReadable(true);
+        return fileName;
+    }
+
+    private String getFileExtension(MultipartFile multipartFile) {
+        String contentType = multipartFile.getContentType();
+        if (contentType.contains("image/jpeg")) {
+            return ".jpg";
+        } else if (contentType.contains("image/png")) {
+            return ".png";
+        }
+
+        throw new InvalidFileExtensionException();
+    }
+
+    public byte[] getPostImageBytes(Long imageId) {
+        Image image = imageRepository.findById(imageId).orElseThrow(ImageNotFoundException::new);
+        return imageConvertToBytes(image);
+    }
+
+    private byte[] imageConvertToBytes(Image image) {
+        try (FileInputStream fileInputStream =
+                     new FileInputStream(location + File.separator + image.getImageName())) {
+            return fileInputStream.readAllBytes();
+        } catch (IOException e) {
+            throw new ImageNotReadable();
+        }
+    }
+
+    public void removeImageFiles(List<Image> images) {
+        images.stream()
+                .map(Image::getImageName)
+                .forEach(imageName -> {
+                    try {
+                        Files.delete(Paths.get(location + File.separator + imageName));
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+    }
+}


### PR DESCRIPTION
- 게시글 저장 후 이미지 리스트 일괄 등록
- 게시글 조회 시 사진 ID 포함
- 각 이미지 조회 API 추가
- 게시글 삭제 시 이미지 데이터 및 이미지 파일 삭제